### PR TITLE
check default SimpleRDF store

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function SimpleRDF (context, iri, graph, store) {
 
   SimpleRDFLite.call(this, context, iri, graph)
 
-  this._store = store || new LdpStore()
+  this._store = SimpleRDF.store || store || new LdpStore()
 }
 
 util.inherits(SimpleRDF, SimpleRDFLite)


### PR DESCRIPTION
The idea is the following:

If I am using ALWAYS a different store than LDP, then at this stage, it would be much nicer for me to just say `SimpleRDF()` without doing this super duper ugly thing `SimpleRDF(null, null, null, store)`

So, if we set it

```
SimpleRDF.store = new FSStore()
```

Then, it should work anywhere !
