### PR TITLE
moved context code to own class

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,42 @@
+function Context (json) {
+  this._json = json
+}
+
+Context.prototype.description = function (property) {
+  if (!(property in this._json)) {
+    return null
+  }
+
+  var json = this._json[property]
+  var description = {}
+
+  description.property = property
+  description.options = {
+    array: false,
+    namedNode: false
+  }
+
+  if (typeof json === 'string') {
+    description.predicate = json
+  } else {
+    description.predicate = json['@id']
+    description.options.array = '@array' in json && json['@array']
+    description.options.namedNode = '@type' in json && json['@type'] === '@id'
+  }
+
+  return description
+}
+
+Context.prototype.descriptions = function () {
+  var self = this
+
+  return self.properties().map(function (property) {
+    return self.description(property)
+  })
+}
+
+Context.prototype.properties = function () {
+  return Object.keys(this._json)
+}
+
+module.exports = Context

--- a/lite.js
+++ b/lite.js
@@ -1,5 +1,6 @@
 var rdf = require('rdf-ext')
 var SimpleArray = require('./lib/array')
+var SimpleContext = require('./lib/context')
 
 function buildIri (iri) {
   if (typeof iri === 'string') {
@@ -125,25 +126,14 @@ SimpleRDF.prototype.context = function (context) {
   var self = this
 
   if (context) {
-    self._context = context
+    self._context = context instanceof SimpleContext ? context : new SimpleContext(context)
 
-    Object.keys(context).forEach(function (key) {
-      var value = context[key]
-      var options = {}
+    self._context.descriptions().forEach(function (description) {
+      // access values with full IRI
+      addProperty.call(self, description.predicate, description.predicate, description.options)
 
-      if (typeof value === 'string') {
-        // access values with full IRI
-        addProperty.call(self, value, value, options)
-
-        // access values with short property
-        addProperty.call(self, key, value, options)
-      } else {
-        options.array = '@array' in value && value['@array']
-        options.namedNode = '@type' in value && value['@type'] === '@id'
-
-        addProperty.call(self, value['@id'], value['@id'], options)
-        addProperty.call(self, key, value['@id'], options)
-      }
+      // access values with short property
+      addProperty.call(self, description.property, description.predicate, description.options)
     })
   }
 


### PR DESCRIPTION
For the future it's better to have a separate Context class for at least two reasons:

**Implementation using Proxy**
A proxy implementation would just lookup the settings for the property on read/write access. No loop is required. With the `.description` method the same code can be used.

**Methods**
Adding methods requires knowing the property and the predicate, to attach the method to both properties. Even if we would remove the predicate alias property support, it would be nice to attach methods with an IRI and not (only) with the property name. This would require reverse property lookup. The Context class would be the best place for this.

Also the code is better structured and writing tests should be easier.
