### PR TITLE
use SimpleRDF object to handle BlankNodes and NamedNodes

### DIFF
--- a/lite.js
+++ b/lite.js
@@ -135,7 +135,7 @@ function addValues (self, predicate, options, values) {
 
 function getValuesArray (self, predicate, options) {
   return self._graph.match(self._iri, predicate).map((triple) => {
-    if (triple.object.interfaceName === 'BlankNode') {
+    if (triple.object.interfaceName !== 'Literal') {
       return self.child(triple.object)
     } else {
       return triple.object.toString()

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,8 @@ var blogContext = {
   },
   headline: 'http://schema.org/headline',
   content: 'http://schema.org/content',
-  version: 'http://schema.org/version'
+  version: 'http://schema.org/version',
+  sameAs: 'http://schema.org/sameAs'
 }
 
 var blogIri = 'http://example.org/blog'
@@ -244,6 +245,22 @@ describe('simplerdf', () => {
 
     assert.equal(blog.provider.name, 'test')
     assert.equal(blog.provider.getName(), 'test')
+  })
+
+  it('should use a SimpleRDF object to handle NamedNodes', () => {
+    let blog = simple(blogContext, blogIri)
+
+    blog.sameAs = rdf.createNamedNode(blogIri + '/theSame')
+
+    assert(blog.sameAs instanceof simple.SimpleRDF)
+  })
+
+  it('should use a SimpleRDF object to handle BlankNodes', () => {
+    let blog = simple(blogContext, blogIri)
+
+    blog.sameAs = rdf.createBlankNode()
+
+    assert(blog.sameAs instanceof simple.SimpleRDF)
   })
 
   it('.get should fetch an object from the store with Promise API', (done) => {


### PR DESCRIPTION
@nicola we discussed this already. Expect Literals everything should be handled with SimpleRDF objects. BlankNodes were already handled that way. This PRs changes the behavior for NamedNodes + addes tests.
