### PR TITLE
Cache single values, use Array if there are multiple values

### DIFF
--- a/lite.js
+++ b/lite.js
@@ -150,8 +150,8 @@ function getValues (self, predicate, options) {
 
   let values = getValuesArray(self, predicate, options)
 
-  if (!options.array) {
-    values = values.shift()
+  if (!options.array && values.length <= 1) {
+    values = self._objects[predicate] = values.shift()
   } else {
     values = self._objects[predicate] = new SimpleArray(
         addValues.bind(null, self, predicate, options),

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,33 @@ describe('simplerdf', () => {
     assert(simple.isArray(posts))
   })
 
+  it('getter should use Arrays if there are multiple values', () => {
+    let graph = blogGraph.clone()
+
+    graph.add(rdf.createTriple(
+      rdf.createNamedNode(blogIri),
+      rdf.createNamedNode('http://schema.org/name'),
+      rdf.createLiteral('simple blog second name')))
+
+    let blog = simple(blogContext, blogIri, graph)
+
+    let names = blog.name
+
+    assert(simple.isArray(names))
+  })
+
+  it('getter should cache values', () => {
+    let graph = blogGraph.clone()
+
+    let blog = simple(blogContext, blogIri, graph)
+
+    assert(!('http://schema.org/name' in blog._objects))
+
+    let names = blog.name
+
+    assert(('http://schema.org/name' in blog._objects))
+  })
+
   it('setter should support IRI values', () => {
     let blog = simple(blogContext)
     let value = 'http://example.org/provider'


### PR DESCRIPTION
Caching is already done for Array values. I need this to attach methods to SimpleRDF objects.

This patch also detects multiple values and automatically switches to Array-mode.
