### PR TITLE
Use JSON-LD set containers to enforce array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ console.log(me.name)
 
 ### 2) Using arrays (simple pimple)
 
-You want to enforce an property to be always an array? Pass `@array: true` in the schema description!
+You want to enforce an property to be always an array? Pass `'@container': '@set'` in the schema description!
 
 ```javascript
 me.context({
@@ -89,7 +89,7 @@ me.context({
   'knows': {
     '@id': 'http://xmlns.com/foaf/0.1/knows',
     '@type': '@id',
-    '@array': true  // Please send a PR if you have a better way to do this
+    '@container': '@set'
   }
 })
 // now we can use me.knows (this will be an array!)

--- a/examples/deep-structure.js
+++ b/examples/deep-structure.js
@@ -4,7 +4,7 @@ var blogContext = {
   name: 'http://schema.org/name',
   post: {
     '@id': 'http://schema.org/post',
-    '@array': true
+    '@container': '@set'
   },
   headline: 'http://schema.org/headline',
   content: 'http://schema.org/content'

--- a/examples/get-save.js
+++ b/examples/get-save.js
@@ -5,7 +5,7 @@ var blogContext = {
   name: 'http://schema.org/name',
   post: {
     '@id': 'http://schema.org/post',
-    '@array': true
+    '@container': '@set'
   },
   headline: 'http://schema.org/headline',
   content: 'http://schema.org/content'

--- a/examples/setter-getter.js
+++ b/examples/setter-getter.js
@@ -4,7 +4,7 @@ var blogContext = {
   name: 'http://schema.org/name',
   post: {
     '@id': 'http://schema.org/post',
-    '@array': true
+    '@container': '@set'
   },
   headline: 'http://schema.org/headline',
   content: 'http://schema.org/content'

--- a/lib/context.js
+++ b/lib/context.js
@@ -23,7 +23,8 @@ class Context {
       description.predicate = json
     } else {
       description.predicate = json['@id']
-      description.options.array = '@container' in json && json['@container'] === '@set'
+      description.options.array = '@container' in json && json['@container'] === '@set' ||
+        '@array' in json && json['@array'] // legacy form
       description.options.namedNode = '@type' in json && json['@type'] === '@id'
     }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -23,7 +23,7 @@ class Context {
       description.predicate = json
     } else {
       description.predicate = json['@id']
-      description.options.array = '@array' in json && json['@array']
+      description.options.array = '@container' in json && json['@container'] === '@set'
       description.options.namedNode = '@type' in json && json['@type'] === '@id'
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ var blogContext = {
   isFamilyFriendly: 'http://schema.org/isFamilyFriendly',
   post: {
     '@id': 'http://schema.org/post',
-    '@array': true
+    '@container': '@set'
   },
   headline: 'http://schema.org/headline',
   content: 'http://schema.org/content',


### PR DESCRIPTION
Use set container declarations in the JSON-LD context to enforce array values. This is the method in JSON-LD for enforcing the use of an array even for a single value of an attribute. See: https://www.w3.org/TR/json-ld/#sets-and-lists

Closes #51.
